### PR TITLE
Protect API routes with session validation

### DIFF
--- a/cortinados-system/src/app/api/auth/[...nextauth]/route.ts
+++ b/cortinados-system/src/app/api/auth/[...nextauth]/route.ts
@@ -156,3 +156,4 @@ export { handler as GET, handler as POST };
 
 // Exportar configurações para uso em middleware e outras partes
 export { authOptions };
+export { getServerSession } from 'next-auth/next';

--- a/cortinados-system/src/app/api/items/route.ts
+++ b/cortinados-system/src/app/api/items/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession, authOptions } from '../auth/[...nextauth]/route';
 import connectDB from '@/lib/mongodb';
 import Item, { ItemUtils } from '@/models/Item';
 import { StatusItem, TipoItem } from '@/types';
@@ -6,6 +7,14 @@ import { StatusItem, TipoItem } from '@/types';
 // GET /api/items - Listar itens
 export async function GET(request: NextRequest) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({
+        success: false,
+        message: 'Não autenticado'
+      }, { status: 401 });
+    }
+
     await connectDB();
     
     const { searchParams } = new URL(request.url);
@@ -56,6 +65,14 @@ export async function GET(request: NextRequest) {
 // POST /api/items - Criar item
 export async function POST(request: NextRequest) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({
+        success: false,
+        message: 'Não autenticado'
+      }, { status: 401 });
+    }
+
     await connectDB();
     
     const body = await request.json();

--- a/cortinados-system/src/app/api/projects/route.ts
+++ b/cortinados-system/src/app/api/projects/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession, authOptions } from '../auth/[...nextauth]/route';
 import connectDB from '@/lib/mongodb';
 import Project, { ProjectUtils } from '@/models/Project';
 import { StatusProjeto } from '@/types';
@@ -6,6 +7,14 @@ import { StatusProjeto } from '@/types';
 // GET /api/projects - Listar projetos
 export async function GET(request: NextRequest) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({
+        success: false,
+        message: 'Não autenticado'
+      }, { status: 401 });
+    }
+
     await connectDB();
     
     const { searchParams } = new URL(request.url);
@@ -52,6 +61,14 @@ export async function GET(request: NextRequest) {
 // POST /api/projects - Criar projeto
 export async function POST(request: NextRequest) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({
+        success: false,
+        message: 'Não autenticado'
+      }, { status: 401 });
+    }
+
     await connectDB();
     
     const body = await request.json();

--- a/cortinados-system/src/app/api/users/route.ts
+++ b/cortinados-system/src/app/api/users/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession, authOptions } from '../auth/[...nextauth]/route';
 import connectDB from '@/lib/mongodb';
 import User, { UserUtils } from '@/models/User';
 import { UserRole } from '@/types';
@@ -6,6 +7,14 @@ import { UserRole } from '@/types';
 // GET /api/users - Listar usuários
 export async function GET(request: NextRequest) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({
+        success: false,
+        message: 'Não autenticado'
+      }, { status: 401 });
+    }
+
     await connectDB();
     
     const { searchParams } = new URL(request.url);
@@ -40,6 +49,14 @@ export async function GET(request: NextRequest) {
 // POST /api/users - Criar usuário
 export async function POST(request: NextRequest) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({
+        success: false,
+        message: 'Não autenticado'
+      }, { status: 401 });
+    }
+
     await connectDB();
     
     const body = await request.json();

--- a/cortinados-system/src/middleware.ts
+++ b/cortinados-system/src/middleware.ts
@@ -95,9 +95,6 @@ function isPublicRoute(pathname: string): boolean {
     '/auth/login',
     '/auth/register',
     '/api/auth',
-    '/api/users',
-    '/api/projects', 
-    '/api/items',
     '/qr', // QR codes são públicos
     '/favicon.ico',
     '/_next',


### PR DESCRIPTION
## Summary
- require authenticated session in items, projects, and users API handlers
- export getServerSession from auth route module for unified imports
- tighten middleware by removing items/projects/users APIs from public access

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8b0d66f088322abce32dd747069da