### PR TITLE
feat: add dashboard QR code scanner

### DIFF
--- a/cortinados-system/package.json
+++ b/cortinados-system/package.json
@@ -18,7 +18,8 @@
     "qrcode": "^1.5.4",
     "react": "^18",
     "react-dom": "^18",
-    "react-qr-code": "^2.0.18"
+    "react-qr-code": "^2.0.18",
+    "react-qr-reader": "^3.0.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^3.0.0",

--- a/cortinados-system/src/app/dashboard/scanner/page.tsx
+++ b/cortinados-system/src/app/dashboard/scanner/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import dynamic from 'next/dynamic';
+
+const QrReader = dynamic(() => import('react-qr-reader'), { ssr: false });
+
+export default function ScannerPage() {
+  const router = useRouter();
+  const [manualCode, setManualCode] = useState('');
+
+  const handleScan = (value: string | null) => {
+    if (value) {
+      router.push(`/dashboard/tracking/${encodeURIComponent(value)}`);
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (manualCode.trim()) {
+      router.push(`/dashboard/tracking/${encodeURIComponent(manualCode.trim())}`);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Scanner</h1>
+      <div className="w-full max-w-md mx-auto">
+        <QrReader
+          onResult={(result, error) => {
+            if (!!result) handleScan((result as any).text || (result as any).getText?.());
+          }}
+          constraints={{ facingMode: 'environment' }}
+        />
+      </div>
+      <form onSubmit={handleSubmit} className="flex space-x-2 max-w-md mx-auto">
+        <input
+          type="text"
+          value={manualCode}
+          onChange={(e) => setManualCode(e.target.value)}
+          placeholder="Insira o código manualmente"
+          className="flex-1 border border-gray-300 rounded px-3 py-2"
+        />
+        <button
+          type="submit"
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          Buscar
+        </button>
+      </form>
+    </div>
+  );
+}
+

--- a/cortinados-system/src/components/layout/Header.tsx
+++ b/cortinados-system/src/components/layout/Header.tsx
@@ -45,7 +45,8 @@ export function Header() {
   // Navegação funcional baseada em roles
   const getNavigation = (role: UserRole) => {
     const baseNav = [
-      { name: 'Dashboard', href: '/dashboard' }
+      { name: 'Dashboard', href: '/dashboard' },
+      { name: 'Scanner', href: '/dashboard/scanner' }
     ];
 
     const roleNav = {


### PR DESCRIPTION
## Summary
- add QR code scanner route with manual fallback
- link scanner from dashboard header navigation
- include react-qr-reader dependency

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm install react-qr-reader@2.2.1` (fails: 403 Forbidden - unable to fetch package)


------
https://chatgpt.com/codex/tasks/task_e_68a9d8fd98408322aba30727a1153a4e