### PR TITLE
feat: add gestor user management

### DIFF
--- a/cortinados-system/src/app/api/users/[id]/route.ts
+++ b/cortinados-system/src/app/api/users/[id]/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../auth/[...nextauth]/route';
+import connectDB from '@/lib/mongodb';
+import User from '@/models/User';
+import mongoose from 'mongoose';
+
+// PUT /api/users/[id] - Atualizar usuário
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({
+        success: false,
+        message: 'Não autenticado'
+      }, { status: 401 });
+    }
+
+    if ((session.user as any)?.role !== 'gestor') {
+      return NextResponse.json({
+        success: false,
+        message: 'Acesso não autorizado'
+      }, { status: 403 });
+    }
+
+    await connectDB();
+
+    const { id } = params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return NextResponse.json({
+        success: false,
+        message: 'ID inválido'
+      }, { status: 400 });
+    }
+
+    const body = await request.json();
+    const { nome, email, role, telefone, empresa, ativo } = body;
+
+    const usuario = await User.findByIdAndUpdate(
+      id,
+      {
+        ...(nome && { nome }),
+        ...(email && { email }),
+        ...(role && { role }),
+        ...(telefone && { telefone }),
+        ...(empresa && { empresa }),
+        ...(typeof ativo === 'boolean' && { ativo }),
+        atualizadoEm: new Date()
+      },
+      { new: true, runValidators: true }
+    );
+
+    if (!usuario) {
+      return NextResponse.json({
+        success: false,
+        message: 'Usuário não encontrado'
+      }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: 'Usuário atualizado com sucesso',
+      data: {
+        id: usuario._id,
+        nome: usuario.nome,
+        email: usuario.email,
+        role: usuario.role,
+        ativo: usuario.ativo
+      }
+    });
+  } catch (error: any) {
+    return NextResponse.json({
+      success: false,
+      message: 'Erro ao atualizar usuário',
+      error: error.message
+    }, { status: 500 });
+  }
+}

--- a/cortinados-system/src/app/api/users/route.ts
+++ b/cortinados-system/src/app/api/users/route.ts
@@ -15,6 +15,13 @@ export async function GET(request: NextRequest) {
       }, { status: 401 });
     }
 
+    if ((session.user as any)?.role !== 'gestor') {
+      return NextResponse.json({
+        success: false,
+        message: 'Acesso não autorizado'
+      }, { status: 403 });
+    }
+
     await connectDB();
     
     const { searchParams } = new URL(request.url);
@@ -55,6 +62,13 @@ export async function POST(request: NextRequest) {
         success: false,
         message: 'Não autenticado'
       }, { status: 401 });
+    }
+
+    if ((session.user as any)?.role !== 'gestor') {
+      return NextResponse.json({
+        success: false,
+        message: 'Acesso não autorizado'
+      }, { status: 403 });
     }
 
     await connectDB();

--- a/cortinados-system/src/app/dashboard/gestor/usuarios/page.tsx
+++ b/cortinados-system/src/app/dashboard/gestor/usuarios/page.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+
+interface FormData {
+  id?: string | null;
+  nome: string;
+  email: string;
+  senha: string;
+  role: string;
+}
+
+export default function UsuariosPage() {
+  const { data: session } = useSession();
+  const [users, setUsers] = useState<any[]>([]);
+  const [formData, setFormData] = useState<FormData>({
+    id: null,
+    nome: '',
+    email: '',
+    senha: '',
+    role: 'medidor'
+  });
+
+  useEffect(() => {
+    if ((session?.user as any)?.role === 'gestor') {
+      carregarUsuarios();
+    }
+  }, [session]);
+
+  const carregarUsuarios = async () => {
+    try {
+      const res = await fetch('/api/users');
+      const data = await res.json();
+      if (data.success) {
+        setUsers(data.data);
+      }
+    } catch (error) {
+      console.error('Erro ao carregar usuários', error);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      if (formData.id) {
+        await fetch(`/api/users/${formData.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            nome: formData.nome,
+            email: formData.email,
+            role: formData.role
+          })
+        });
+      } else {
+        await fetch('/api/users', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            nome: formData.nome,
+            email: formData.email,
+            senha: formData.senha,
+            role: formData.role
+          })
+        });
+      }
+      setFormData({ id: null, nome: '', email: '', senha: '', role: 'medidor' });
+      carregarUsuarios();
+    } catch (error) {
+      console.error('Erro ao salvar usuário', error);
+    }
+  };
+
+  const handleEdit = (user: any) => {
+    setFormData({
+      id: user._id,
+      nome: user.nome,
+      email: user.email,
+      senha: '',
+      role: user.role
+    });
+  };
+
+  if (!session) return <div className="p-6">Carregando...</div>;
+  if ((session.user as any)?.role !== 'gestor') return <div className="p-6">Acesso negado</div>;
+
+  return (
+    <div className="p-6 space-y-8">
+      <h1 className="text-2xl font-bold">Gestão de Utilizadores</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <div>
+          <label className="block text-sm font-medium">Nome</label>
+          <input
+            type="text"
+            value={formData.nome}
+            onChange={(e) => setFormData({ ...formData, nome: e.target.value })}
+            className="mt-1 w-full border rounded p-2"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Email</label>
+          <input
+            type="email"
+            value={formData.email}
+            onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+            className="mt-1 w-full border rounded p-2"
+            required
+          />
+        </div>
+        {!formData.id && (
+          <div>
+            <label className="block text-sm font-medium">Senha</label>
+            <input
+              type="password"
+              value={formData.senha}
+              onChange={(e) => setFormData({ ...formData, senha: e.target.value })}
+              className="mt-1 w-full border rounded p-2"
+              required
+            />
+          </div>
+        )}
+        <div>
+          <label className="block text-sm font-medium">Role</label>
+          <select
+            value={formData.role}
+            onChange={(e) => setFormData({ ...formData, role: e.target.value })}
+            className="mt-1 w-full border rounded p-2"
+          >
+            <option value="medidor">Medidor</option>
+            <option value="fabrica_trk">Fábrica TRK</option>
+            <option value="fabrica_crt">Fábrica CRT</option>
+            <option value="logistica">Logística</option>
+            <option value="instalador">Instalador</option>
+            <option value="gestor">Gestor</option>
+          </select>
+        </div>
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+          {formData.id ? 'Atualizar' : 'Criar'} Utilizador
+        </button>
+      </form>
+
+      <div>
+        <h2 className="text-xl font-semibold mb-2">Utilizadores</h2>
+        <table className="min-w-full border">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="p-2 border">Nome</th>
+              <th className="p-2 border">Email</th>
+              <th className="p-2 border">Role</th>
+              <th className="p-2 border">Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u._id} className="text-sm">
+                <td className="p-2 border">{u.nome}</td>
+                <td className="p-2 border">{u.email}</td>
+                <td className="p-2 border">{u.role}</td>
+                <td className="p-2 border">
+                  <button
+                    onClick={() => handleEdit(u)}
+                    className="text-blue-600 hover:underline mr-2"
+                  >
+                    Editar
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/cortinados-system/src/middleware.ts
+++ b/cortinados-system/src/middleware.ts
@@ -23,6 +23,7 @@ const ROLE_ROUTES: Record<string, UserRole[]> = {
   // Gestão - apenas gestores
   '/dashboard/relatorios': ['gestor'],
   '/dashboard/usuarios': ['gestor'],
+  '/dashboard/gestor/usuarios': ['gestor'],
   '/dashboard/projetos': ['gestor'],
   '/dashboard/configuracoes': ['gestor']
 };


### PR DESCRIPTION
## Summary
- add manager-only user management page
- restrict user API to gestores and support updates
- guard middleware for gestor user routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: React lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68acb02931a08322b82a992ffed2302f